### PR TITLE
Add option to do not auto open quickfix window

### DIFF
--- a/autoload/rubyfmt.vim
+++ b/autoload/rubyfmt.vim
@@ -25,7 +25,9 @@ function! rubyfmt#Format() abort
     endfor
     if !empty(errors)
       call setqflist(errors)
-      copen | cc
+      if get(g:, "rubyfmt_autoopen", 1)
+        copen | cc
+      end
     endif
   finally
     call winrestview(curw)


### PR DESCRIPTION
This add a `g:rubyfmt_autoopen` option, default "1". If it's set to "0"
it'll not auto open the quickfix window.
